### PR TITLE
Fix Tailwind dark mode configuration

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-    darkMode: ["class"],
+    darkMode: "class",
     content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary
- fix Tailwind config to use correct `darkMode` string

## Testing
- `npm run lint` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_b_689ce6773414832ea1e5069d92864c02