### PR TITLE
Add minimal job matching API prototype

### DIFF
--- a/app/api/candidates/route.ts
+++ b/app/api/candidates/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { candidates, Candidate } from '@/lib/data';
+
+export async function GET() {
+  return NextResponse.json(candidates);
+}
+
+export async function POST(req: NextRequest) {
+  const candidate: Candidate = await req.json();
+  candidate.id = candidates.length + 1;
+  candidates.push(candidate);
+  return NextResponse.json(candidate, { status: 201 });
+}

--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { jobs, Job } from '@/lib/data';
+
+export async function GET() {
+  return NextResponse.json(jobs);
+}
+
+export async function POST(req: NextRequest) {
+  const job: Job = await req.json();
+  job.id = jobs.length + 1;
+  jobs.push(job);
+  return NextResponse.json(job, { status: 201 });
+}

--- a/app/api/match/route.ts
+++ b/app/api/match/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { jobs, candidates } from '@/lib/data';
+
+export async function POST(req: NextRequest) {
+  const { candidateId } = await req.json();
+  const candidate = candidates.find(c => c.id === candidateId);
+  if (!candidate) {
+    return NextResponse.json({ error: 'Candidate not found' }, { status: 404 });
+  }
+
+  const matches = jobs
+    .map((job) => ({
+      job,
+      score: job.skills.filter((s) => candidate.skills.includes(s)).length,
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((entry) => entry.job);
+
+  return NextResponse.json(matches);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,9 @@
+export default function Home() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Job Matcher Demo</h1>
+      <p className="mt-4">Simple API demo for posting jobs, candidates and matching based on skills.</p>
+      <p className="mt-2">API routes: /api/jobs, /api/candidates, /api/match.</p>
+    </main>
+  );
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,19 @@
+export interface Job {
+  id: number;
+  title: string;
+  description: string;
+  skills: string[];
+  salary: number;
+}
+
+export interface Candidate {
+  id: number;
+  name: string;
+  bio: string;
+  skills: string[];
+  salaryExpectation: number;
+}
+
+// In-memory stores for demo purposes.
+export const jobs: Job[] = [];
+export const candidates: Candidate[] = [];


### PR DESCRIPTION
## Summary
- set up in-memory data models for jobs and candidates
- add API routes to create and list jobs and candidates
- add matching endpoint to rank jobs for a candidate by overlapping skills
- add basic home page describing API

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)


------
https://chatgpt.com/codex/tasks/task_b_689ce79e16d4832eb61abe79a33d1f67